### PR TITLE
Change url for npmjs

### DIFF
--- a/content/faq.md
+++ b/content/faq.md
@@ -4,7 +4,7 @@
 <!-- ## What is io.js? -->
 ## io.jsとは?
 
-<!-- [io.js](https://github.com/iojs/io.js) is a JavaScript platform built on [Chrome's V8 runtime](http://code.google.com/p/v8/). This project began as a fork of [Joyent's Node.js™](https://nodejs.org/) and is compatible with the [npm](https://www.npmjs.org/) ecosystem. -->
+<!-- [io.js](https://github.com/iojs/io.js) is a JavaScript platform built on [Chrome's V8 runtime](http://code.google.com/p/v8/). This project began as a fork of [Joyent's Node.js™](https://nodejs.org/) and is compatible with the [npm](https://www.npmjs.com/) ecosystem. -->
 [io.js](https://github.com/iojs/io.js)は[ChromeのV8 runtime](http://code.google.com/p/v8/)上に作られたJavaScriptプラットフォームです。[JoyentのNode.js™](https://nodejs.org/)のフォークとして始まり、npm互換となっています。
 
 <!-- ## Why? -->

--- a/content/index.md
+++ b/content/index.md
@@ -3,8 +3,8 @@
 <!-- Bringing [ES6](es6.html) to the Node Community! -->
 [ES6](es6.html)をNodeコミュニティへ！
 
-<!-- [io.js](https://github.com/iojs/io.js) is an [npm](https://www.npmjs.org/) compatible platform originally based on [node.js](https://nodejs.org/)&#8482;. -->
-[io.js](https://github.com/iojs/io.js)は、[node.js](https://nodejs.org/)&#8482;をベースに作られた[npm](https://www.npmjs.org/)互換プラットフォームです。
+<!-- [io.js](https://github.com/iojs/io.js) is an [npm](https://www.npmjs.com/) compatible platform originally based on [node.js](https://nodejs.org/)&#8482;. -->
+[io.js](https://github.com/iojs/io.js)は、[node.js](https://nodejs.org/)&#8482;をベースに作られた[npm](https://www.npmjs.com/)互換プラットフォームです。
 
 [![io.js](../images/1.0.0.png)](https://iojs.org/dist/v1.2.0/)
 


### PR DESCRIPTION
www.npm.org now changes into www.npmjs.com 
ref: [iojs/website#156](https://github.com/iojs/website/pull/156/files)
