### PR TITLE
Modify markdown comment style and add newline

### DIFF
--- a/weekly/2015-02-13.md
+++ b/weekly/2015-02-13.md
@@ -1,24 +1,42 @@
-<!-- io.js Week of February 13th 2015
-29 language localization effort, 1.2.0 release, and much more. -->
+<!--
+io.js Week of February 13th 2015
+29 language localization effort, 1.2.0 release, and much more.
+-->
+
 # io.jsウィークリーアップデート 2015/2/13
 29言語へのローカリゼーション、バージョン1.2.0リリース 他
 
 ---
 
-<!-- ## io.js support added by...  -->
+<!--
+## io.js support added by...
+-->
+
 ## io.jsサポートの追加
-* [Postmark](http://blog.postmarkapp.com/post/110829734198/its-official-were-getting-cozy-with-node-js) 
+* [Postmark](http://blog.postmarkapp.com/post/110829734198/its-official-were-getting-cozy-with-node-js)
 * [node-serialport](https://github.com/voodootikigod/node-serialport/issues/439)
 * [Microsoft Azure](http://azure.microsoft.com/en-us/documentation/articles/web-sites-nodejs-iojs/)
 
-<!-- ## io.js breaks 10,000 stars on GitHub -->
+<!--
+## io.js breaks 10,000 stars on GitHub
+-->
+
 ## Githubでio.jsが 10,000 Star を達成
-<!-- On Feb. 13, io.js reached the goal of 10,000 stars on GitHub. We couldn't have done it without the support of the amazing community behind JavaScript. Thank you alll! -->
+
+<!--
+On Feb. 13, io.js reached the goal of 10,000 stars on GitHub. We couldn't have done it without the support of the amazing community behind JavaScript. Thank you alll!
+-->
+
 2月13日、JavaScriptコミュニティの素晴らしいサポートのお陰で、io.jsに10,000のGithub Starがつきました。本当にありがとう！
 
-<!-- ## io.js 1.2.0 released -->
+<!--
+## io.js 1.2.0 released
+-->
+
 ## io.js 1.2.0 リリース
-<!-- * **stream**: Simpler stream construction ([readable-stream/issues#102[(https://github.com/iojs/readable-stream/issues/102))
+
+<!--
+* **stream**: Simpler stream construction ([readable-stream/issues#102[(https://github.com/iojs/readable-stream/issues/102))
 * **dns**: `lookup()` now supports an `'all'` boolean option, default to `false` but when turned on will cause the method to return an array of all resolved names for an address, see, ([iojs/pull#744](https://github.com/iojs/io.js/pull/744))
 * **assert**: Remove `prototype` property comparison in `deepEqual()` ([iojs/issues#636](https://github.com/iojs/io.js/pull/636)); introduce a `deepStrictEqual()` method to mirror `deepEqual()` but performs strict equality checks on primitives ([iojs/issues#639](https://github.com/iojs/io.js/pull/639)).
 * **tracing**: Add [LTTng](http://lttng.org/) (Linux Trace Toolkit Next Generation) when compiled with the `--with-lttng option`. Trace points match those available for DTrace and ETW. ([iojs/issues#702](https://github.com/iojs/io.js/pull/702))
@@ -27,7 +45,9 @@
 * **libuv** upgrade to 1.4.0, see libuv [ChangeLog](https://github.com/libuv/libuv/blob/v1.x/ChangeLog)
 * Add new collaborators:
   * Aleksey Smolenchuk (@lxe)
-  * Shigeki Ohtsu (@shigeki) -->
+  * Shigeki Ohtsu (@shigeki)
+-->
+
 * **stream**: よりシンプルなstream作成。 ([readable-stream/issues#102](https://github.com/iojs/readable-stream/issues/102))
 * **dns**: `lookup()`メソッド で `'all'` オプションをサポート。この設定を有効にすると名前の解決が行われたすべてのアドレスを配列で返します(デフォルトは`false`に設定)。 ([iojs/pull#744](https://github.com/iojs/io.js/pull/744))
 * **assert**: `deepEqual()`から`prototype`プロパティの比較を外しました。 ([iojs/issues#636](https://github.com/iojs/io.js/pull/636)) `deepEqual()`のミラーとして`deepStrictEqual()`メソッドを追加し、こちらがプリミティブの比較を行います。 ([iojs/issues#639](https://github.com/iojs/io.js/pull/639))
@@ -39,27 +59,42 @@
   * Aleksey Smolenchuk (@lxe)
   * Shigeki Ohtsu (@shigeki)
 
-<!-- ## Opened our doors to the international community -->
+<!--
+## Opened our doors to the international community
+-->
+
 ## 世界中のコミュニティを受け入れ
 
-<!-- View the [original article](https://medium.com/@mikeal/how-io-js-built-a-146-person-27-language-localization-effort-in-one-day-65e5b1c49a62) on Medium.
+<!--
+View the [original article](https://medium.com/@mikeal/how-io-js-built-a-146-person-27-language-localization-effort-in-one-day-65e5b1c49a62) on Medium.
 * Added interested contributors to teams for their language.
 * Teams registered Twitter accounts for their teams and other relevant social media accounts.
-* Teams came up with their own ways of working together, and they became more of "community organizers," as opposed to just "translators" -->
+* Teams came up with their own ways of working together, and they became more of "community organizers," as opposed to just "translators"
+-->
+
 Mediumに載せた[元記事](https://medium.com/@mikeal/how-io-js-built-a-146-person-27-language-localization-effort-in-one-day-65e5b1c49a62)を参照
 * 参加したいと言ってくれたメンバーを各言語チームのコントリビューターとして追加
 * 各チームごとにTwitterや地域に特化したソーシャルメディアアカウントを設置
 * 各チームが独自にワークフローを設定することで「翻訳者」というよりも「コミュニティオーガナイザー」に
 
-<!-- ### Stats for Localizations: -->
+<!--
+### Stats for Localizations:
+-->
+
 ### ローカリゼーションの状況:
 
-<!-- * 146 people signed up to help with the localizations the first day (over 160 signed up now)
-* 27 languages communities created the first day (already up to 29) -->
+<!--
+* 146 people signed up to help with the localizations the first day (over 160 signed up now)
+* 27 languages communities created the first day (already up to 29)
+-->
+
 * 呼びかけ初日に146人がローカリゼーションチームに参加 (現在は160人以上)
 * 初日だけで27言語のローカリゼーションチームが発足(現在は29言語)
 
-<!-- ### Language Communities -->
+<!--
+### Language Communities
+-->
+
 ### 各言語のコミュニティ
 
 * [`iojs-bn`](https://github.com/iojs/iojs-bn) ベンガル語コミュニティ
@@ -93,51 +128,82 @@ Mediumに載せた[元記事](https://medium.com/@mikeal/how-io-js-built-a-146-p
 * [`iojs-uk`](https://github.com/iojs/iojs-uk) ウクライナ語コミュニティ
 
 
-<!-- ## io.js and Node.js -->
+<!--
+## io.js and Node.js
+-->
+
 ## io.js と Node.js
 
-<!-- View the [original article](https://medium.com/@iojs/io-js-and-a-node-js-foundation-4e14699fb7be) on Medium.
-* Scott Hammond, CEO of Joyent, expressed his desire to bring io.js back to the node.js.-->
+<!--
+View the [original article](https://medium.com/@iojs/io-js-and-a-node-js-foundation-4e14699fb7be) on Medium.
+* Scott Hammond, CEO of Joyent, expressed his desire to bring io.js back to the node.js.
+-->
+
 [元記事を参照](http://blog.iojs.jp/io.js_and_node.js_Foundation.html)
 * Joyent CEOのScott Hammond氏よりio.jsをnode.jsに戻したい意向を受けました
 
-<!-- #### In only a few months io.js...  -->
+<!--
+#### In only a few months io.js...
+-->
+
 ### ここ数ヶ月でio.jsは...
-<!-- * Has grown to 23 active core team members
+
+<!--
+* Has grown to 23 active core team members
 * Has several working groups
 * Has 29 language localization teams,
 * Has drawn more contributors to the project than we’ve ever had in the history of node.js, and
-* Has been able to release quality software at a good pace with the support of an exceptional community. -->
+* Has been able to release quality software at a good pace with the support of an exceptional community.
+-->
+
 * 23人のコアチームに成長
 * いくつかのワーキンググループを結成
 * 29言語へのローカリゼーションチームを発足
 * node.js史上最多のプロジェクト参加者を惹きつけることに成功
 * コミュニティのサポートを受けて、良いペースで質の高いソフトウェアのリリース
 
-<!-- > We are eager to put this all behind us but we can’t sacrifice the progress we’ve made or the principles and open governance that got us here. -->
+<!--
+> We are eager to put this all behind us but we can’t sacrifice the progress we’ve made or the principles and open governance that got us here.
+-->
+
 > 分離についてはみんな早く水に流したいと思っていますが、これまでの進捗や、それを推し進めたオープンガバナンスの理念を捨てるわけにはいきません。
 
-<!-- ### The Future -->
+<!--
+### The Future
+-->
+
 ### 今後について
 
-<!-- * Talks with the node.js foundation are ongoing.
+<!--
+* Talks with the node.js foundation are ongoing.
 * Once the foundation has a technical governance model you will see an issue on io.js’ GitHub about whether io.js should join.
 
-  * This will be discussed and voted on openly in a public TC meeting following the governance rules we’ve already built. -->
+  * This will be discussed and voted on openly in a public TC meeting following the governance rules we’ve already built.
+-->
+
 * node.js foundation との話し合いは現在も進行中です
 * node.js Foundationがテクニカルガバナンスモデルを作り次第、io.jsのGithub issueにてio.jsがnode.jsに戻るべきかのディスカッションを行います
   * 私達の作ったガバナンスモデルにもとづいて、公開TCミーティングにてディスカッションとvoteを行います
 
-<!-- > For the community, nothing has changed. -->
+<!--
+> For the community, nothing has changed.
+-->
+
 > コミュニティの皆さんにとって現状は何も変わりません。
 
-<!-- ### What to do right now -->
+<!--
+### What to do right now
+-->
+
 ### 今できること
 
-<!-- * Continue to send your pull requests to io.js
+<!--
+* Continue to send your pull requests to io.js
 * Join one of the 27 [language localization teams](https://github.com/iojs/website/issues/125)
 * Contribute to io.js’ working groups ([streams](https://github.com/iojs/readable-stream), [website](https://github.com/iojs/website), [evangelism](https://github.com/iojs/website/labels/evangelism), [tracing](https://github.com/iojs/tracing-wg), [build](https://github.com/iojs/build), [roadmap](https://github.com/iojs/roadmap)) and
-* Continue to adopt io.js in your applications. -->
+* Continue to adopt io.js in your applications.
+-->
+
 * 今までどおりpull requestsをio.jsに送る
 * [27言語のローカリゼーションチーム](https://github.com/iojs/website/issues/125)に参加する
 * io.jsのワーキンググループに参加する([streams](https://github.com/iojs/readable-stream), [website](https://github.com/iojs/website), [evangelism](https://github.com/iojs/website/labels/evangelism), [tracing](https://github.com/iojs/tracing-wg), [build](https://github.com/iojs/build), [roadmap](https://github.com/iojs/roadmap))

--- a/weekly/2015-02-20.md
+++ b/weekly/2015-02-20.md
@@ -1,35 +1,60 @@
-<!-- #io.js Week of February 20th 2015
-1.3.0 release, MongoDB, the roadmap and more. -->
+<!--
+#io.js Week of February 20th 2015
+1.3.0 release, MongoDB, the roadmap and more.
+-->
+
 # io.jsウィークリーアップデート 2015/2/20
 1.3.0リリース、 MongoDB、 ロードマップ　他
 
 ---
 
-<!-- ## io.js Releases 1.3.0 -->
+<!--
+## io.js Releases 1.3.0
+-->
+
 ## io.js 1.3.0 リリース
-<!-- Notable changes include: -->
+
+<!--
+Notable changes include:
+-->
+
 主な変更点:
 
-<!-- * **url**: `url.resolve('/path/to/file', '.')` now returns `/path/to/` with the trailing slash, `url.resolve('/', '.')` returns `/` [#278](https://github.com/iojs/io.js/pull/278) (Amir Saboury)
-* **tls**: The default cipher suite used by `tls` and `https` has been changed to one that achieves Perfect Forward Secrecy with all modern browsers. Additionally, insecure RC4 ciphers have been excluded. If you absolutely require RC4, please specify your own cipher suites. [#826](https://github.com/iojs/io.js/pull/826) (Roman Reiss) -->
+<!--
+* **url**: `url.resolve('/path/to/file', '.')` now returns `/path/to/` with the trailing slash, `url.resolve('/', '.')` returns `/` [#278](https://github.com/iojs/io.js/pull/278) (Amir Saboury)
+* **tls**: The default cipher suite used by `tls` and `https` has been changed to one that achieves Perfect Forward Secrecy with all modern browsers. Additionally, insecure RC4 ciphers have been excluded. If you absolutely require RC4, please specify your own cipher suites. [#826](https://github.com/iojs/io.js/pull/826) (Roman Reiss)
+-->
+
 * **url**: `url.resolve('/path/to/file', '.')`の戻り値が`/path/to/`のように末尾にスラッシュが付与されるように、`url.resolve('/', '.')` の戻り値は`/`に変更。[#278](https://github.com/iojs/io.js/pull/278) (Amir Saboury)
 * **tls**: `tls` と `https`の使用しているデフォルトcipher suiteをすべてのモダンブラウザでPerfect Forward Secrecyに対応している物に変更。また、安全でないRC4 ciphersは除外されています。RC4がどうしても必要な場合はcipher suitesを個別に指定してください. [#826](https://github.com/iojs/io.js/pull/826) (Roman Reiss)
 
-<!-- ## Notable Events in the Community -->
+<!--
+## Notable Events in the Community
+-->
+
 ## コミュニティの動き
-<!-- * **Node Governance** - [William Bert](https://twitter.com/williamjohnbert) created http://nodegovernance.io/ to alert Scott Hammond, CEO of Joyent, of the desire of the community for the io.js open-governance model to be the base upon which the Node Foundation's Technical Committee. The response from the community was _fantastic_!
+
+<!--
+* **Node Governance** - [William Bert](https://twitter.com/williamjohnbert) created http://nodegovernance.io/ to alert Scott Hammond, CEO of Joyent, of the desire of the community for the io.js open-governance model to be the base upon which the Node Foundation's Technical Committee. The response from the community was _fantastic_!
 * **Node.js and io.js Performance Improves** - Raygun.io did performance tests with both Node.js and io.js recently, and both are improving performance with each release! [Read the full article](https://raygun.io/blog/2015/02/node-js-performance-node-js-vs-io-js/).
 * **LTTng Basics** - [LTTing Basics](https://asciinema.org/a/16785) with io.js by user jgalar on asciinema
-* **io.js Roadmap Slides** - Slide deck for the current roadmap of io.js up.  -->
+* **io.js Roadmap Slides** - Slide deck for the current roadmap of io.js up.
+-->
+
 * **Node Governance** - [William Bert](https://twitter.com/williamjohnbert)がJoyent CEOのScott Hammond宛に Node Foundation のTechnical Committeeでio.jsのオープンガバナンスモデルを採用するよう呼びかける[http://nodegovernance.io/](http://nodegovernance.io/) を作成、
 コミュニティの_素晴らしい_反応がありました!
 * **Node.js と io.js のパフォーマンス改善** - Raygun.io がNode.js と io.jsパフォーマンステストを実施、どちらもリリースごとにパフォーマンスが改善！[元記事はこちら](https://raygun.io/blog/2015/02/node-js-performance-node-js-vs-io-js/)
 * **LTTngの基礎** - asciinemaユーザー jgalar によるio.jsでの[LTTngの基礎](https://asciinema.org/a/16785)
 * **io.js ロードマップスライド** - io.jsのロードマップについてのスライドを作成
 
-<!-- ### io.js Support Added  -->
+<!--
+### io.js Support Added
+-->
+
 ### io.jsサポートの追加
-<!-- * [TravisCI](https://travis-ci.org/) added io.js.The day the last Weekly Update was posted, Hiro Asari (あさり) [tweeted](https://twitter.com/hiro_asari/status/566268486012633088) that about 10% of Node projects were running io.js.
+
+<!--
+* [TravisCI](https://travis-ci.org/) added io.js.The day the last Weekly Update was posted, Hiro Asari (あさり) [tweeted](https://twitter.com/hiro_asari/status/566268486012633088) that about 10% of Node projects were running io.js.
 * @thlorenz updated [nad](https://github.com/thlorenz/nad), Node Addon Developer, to [support io.js](https://twitter.com/thlorenz/status/566328088121081856)
 * [Catberry.js](https://github.com/catberry/catberry) added support for io.js.
 * Official mongodb node module supports io.js in [v. 2.0.16 2015-02-16](https://github.com/mongodb/node-mongodb-native/blob/2.0/HISTORY.md).
@@ -38,7 +63,9 @@
 * [TDPAHACLPlugin](https://github.com/neilstuartcraig/TDPAHACLPlugin) and [TDPAHAuthPlugin](https://github.com/neilstuartcraig/TDPAHAuthPlugin) for [actionHero](http://www.actionherojs.com/) now support io.js.
 * [node-sass](https://npmjs.org/package/node-sass) added support for io.js 1.2 in node-sass [v. 2.0.1](https://github.com/sass/node-sass/issues/655)
 * [total.js](https://www.totaljs.com/) added support for io.js in [v. 1.7.1](https://github.com/totaljs/framework/releases/tag/v1.7.1)
-* [Clever Cloud](https://www.clever-cloud.com/) added [support for io.js](https://www.clever-cloud.com/blog/features/2015/01/23/introducing-io.js/) -->
+* [Clever Cloud](https://www.clever-cloud.com/) added [support for io.js](https://www.clever-cloud.com/blog/features/2015/01/23/introducing-io.js/)
+-->
+
 * [TravisCI](https://travis-ci.org/) が io.jsのサポートを追加Hiro Asari(あさり)の[ツイート](https://twitter.com/hiro_asari/status/566268486012633088)によると約10%のNodeプロジェクトがio.jsを利用
 * @thlorenz が Node Addon Developer [nad](https://github.com/thlorenz/nad)をアップデート、[io.jsのサポート](https://twitter.com/thlorenz/status/566328088121081856)を追加
 * [Catberry.js](https://github.com/catberry/catberry) が io.jsのサポートを追加
@@ -50,12 +77,19 @@
 * [total.js](https://www.totaljs.com/) が [v. 1.7.1](https://github.com/totaljs/framework/releases/tag/v1.7.1) でio.jsをサポート
 * [Clever Cloud](https://www.clever-cloud.com/) が [io.jsのサポート](https://www.clever-cloud.com/blog/features/2015/01/23/introducing-io.js/)を追加
 
-<!-- ## io.js Working Group Meetings -->
+<!--
+## io.js Working Group Meetings
+-->
+
 ## io.js ワーキンググループ ミーティング
-<!-- * io.js Tracing Working Group Meeting - Feb. 19, 2015: [YouTube](https://www.youtube.com/watch?v=wvBVjg8jkv0) - [Minutes](https://docs.google.com/document/d/1_ApOMt03xHVkaGpTEPMDIrtkjXOzg3Hh4ZcyfhvMHx4/edit)
+
+<!--
+* io.js Tracing Working Group Meeting - Feb. 19, 2015: [YouTube](https://www.youtube.com/watch?v=wvBVjg8jkv0) - [Minutes](https://docs.google.com/document/d/1_ApOMt03xHVkaGpTEPMDIrtkjXOzg3Hh4ZcyfhvMHx4/edit)
 * io.js Build Working Group Meeting - Feb. 19, 2015: [YouTube](https://www.youtube.com/watch?v=OKQi3pTF7fs) - [SoundCloud](https://soundcloud.com/iojs/iojs-build-wg-meeting-2015-02-19) - [Minutes](https://docs.google.com/document/d/1vRhsYBs4Hw6vRu55h5eWTwDzS1NctxdTvMMEnCbDs14/edit)
 * io.js Technical Committee Meeting - Feb. 18, 2015: [YouTube](https://www.youtube.com/watch?v=jeBPYLJ2_Yc) - [SoundCloud](https://soundcloud.com/iojs/iojs-tc-meeting-meeting-2015-02-18) - [Minutes](https://docs.google.com/document/d/1JnujRu6Rfnp6wvbvwCfxXnsjLySunQ_yah91pkvSFdQ/edit)
-* io.js Website Working Group Meeting - Feb. 16, 2015: [YouTube](https://www.youtube.com/watch?v=UKDKhFV61ZA) - [SoundCloud](https://soundcloud.com/iojs/iojs-website-wg-meeting-2015-02-16) - [Minutes](https://docs.google.com/document/d/1R8JmOoyr64tt-QOj27bD19ZOWg63CujW7GeaAHIIkUs/edit) -->
+* io.js Website Working Group Meeting - Feb. 16, 2015: [YouTube](https://www.youtube.com/watch?v=UKDKhFV61ZA) - [SoundCloud](https://soundcloud.com/iojs/iojs-website-wg-meeting-2015-02-16) - [Minutes](https://docs.google.com/document/d/1R8JmOoyr64tt-QOj27bD19ZOWg63CujW7GeaAHIIkUs/edit)
+-->
+
 * io.js Tracing ワーキンググループ ミーティング - 2015/02/19: [YouTube](https://www.youtube.com/watch?v=wvBVjg8jkv0) - [議事録](https://docs.google.com/document/d/1_ApOMt03xHVkaGpTEPMDIrtkjXOzg3Hh4ZcyfhvMHx4/edit)
 * io.js Build ワーキンググループ ミーティング - 2015/02/19: [YouTube](https://www.youtube.com/watch?v=OKQi3pTF7fs) - [SoundCloud](https://soundcloud.com/iojs/iojs-build-wg-meeting-2015-02-19) - [議事録](https://docs.google.com/document/d/1vRhsYBs4Hw6vRu55h5eWTwDzS1NctxdTvMMEnCbDs14/edit)
 * io.js TC ミーティング - 2015/02/18: [YouTube](https://www.youtube.com/watch?v=jeBPYLJ2_Yc) - [SoundCloud](https://soundcloud.com/iojs/iojs-tc-meeting-meeting-2015-02-18) - [議事録](https://docs.google.com/document/d/1JnujRu6Rfnp6wvbvwCfxXnsjLySunQ_yah91pkvSFdQ/edit)

--- a/weekly/2015-02-27.md
+++ b/weekly/2015-02-27.md
@@ -1,16 +1,27 @@
 <!-- # io.js Week of February 27th
 ARMv8, C++ Streams, 1.4.1 release, a proposal for reconciliation and more. -->
+
 # io.jsウィークリーアップデート 2015/2/27
 ARMv8, C++ Streams, 1.4.1リリース, 和解へのプロポーザル　他
 
 ---
 
-<!-- # io.js 1.4.1 Release -->
+<!--
+# io.js 1.4.1 Release
+-->
+
 ## io.js 1.4.1リリース
-<!-- _Note: version **1.4.0** was tagged and built but not released. A libuv bug was discovered in the process so the release was aborted. We have jumped to 1.4.1 to avoid confusion._ -->
+
+<!--
+ _Note: version **1.4.0** was tagged and built but not released. A libuv bug was discovered in the process so the release was aborted. We have jumped to 1.4.1 to avoid confusion._
+ -->
+
 _注意: バージョン **1.4.0** はタグ付け・ビルドされましたがリリースはされていません（libuvにバグが発見されたためリリースを中止しました）。混乱を避けるため1.4.1へバージョンを上げています。_
 
-<!-- ## Notable changes -->
+<!--
+ ## Notable changes
+-->
+
 ### 主な変更点
 
 * **process** / **promises**:  イベントループの中で、`Promise` が reject され、その `Promise` に対してのエラーハンドラが一つも存在しない時はいつでも `'unhandledRejection'` イベントが `process` オブジェクトに emit されるようになりました。イベントループが回った後で `Promise` が reject され、あるエラーハンドラがそれをキャッチした時に`'rejectionHandled'` イベントが emit されるようになりました。  [#758](https://github.com/iojs/io.js/pull/758) (Petka Antonov)
@@ -24,36 +35,57 @@ _注意: バージョン **1.4.0** はタグ付け・ビルドされましたが
 * **libuv**: libuvを1.4.2 にアップグレードしました。 詳細は [libuv ChangeLog](https://github.com/libuv/libuv/blob/v1.x/ChangeLog) を見てください。
 
 
-<!-- # ARM offers support for io.js on ARMv8 -->
+<!--
+# ARM offers support for io.js on ARMv8
+-->
+
 ## ARMから、ARMv8でのio.jsサポートの意向
 
-<!-- ARM contacted Rod Vagg, lead of the io.js Build Working Group, to offer their support to the io.js project. ARM and their hardware partners are on track to make ARMv8 a viable server platform and the nimble nature of server-side JavaScript make it a perfect fit to run on the new ARM. -->
+<!--
+ARM contacted Rod Vagg, lead of the io.js Build Working Group, to offer their support to the io.js project. ARM and their hardware partners are on track to make ARMv8 a viable server platform and the nimble nature of server-side JavaScript make it a perfect fit to run on the new ARM.
+-->
+
 ARM からRod Vagg(Buildワーキング・グループリード)へio.jsをサポートしたい旨、連絡がありました。ARMと彼らのハードウェアパートナーはARMv8を実用的なサーバーとして仕上げる予定で、実行速度の早いサーバーサイドJavaScriptはARM上で動かすのに最適です。
 
-<!-- Since ARMv8 is already being adopted by mobile device manufacturers, newer versions of V8 already have good support. Because of V8's pivotal role in Android, io.js is perfectly suited to track that support, and even contribute to it given our new relationships with the V8 team. -->
+<!--
+ Since ARMv8 is already being adopted by mobile device manufacturers, newer versions of V8 already have good support. Because of V8's pivotal role in Android, io.js is perfectly suited to track that support, and even contribute to it given our new relationships with the V8 team.
+ -->
+
 ARMv8はすでにモバイル製造において採用されているため、新しいバージョンのV8サポートがあります。特にV8はAndroidにおいて重要な役割を果たしているため、io.jsがこの流れに沿うのは最適です。また最近のV8チームとのコラボレーションにより、io.jsからもARMに貢献できるでしょう。
 
-<!-- From the beginning of the io.js project, Rod has championed the role of ARM for io.js, for IoT, hobbyist, and server use. We already have ARMv6 builds of each release for devices such as Raspberry Pi. and ARMv7 builds for many more popular devices (including the Online Labs ARM-based cloud platform, who have also offered help to io.js). ARMv8 is the logical extension of this, but also has exciting potential for server-side applications, particularly given the new 64-bit support. -->
+<!--
+ From the beginning of the io.js project, Rod has championed the role of ARM for io.js, for IoT, hobbyist, and server use. We already have ARMv6 builds of each release for devices such as Raspberry Pi. and ARMv7 builds for many more popular devices (including the Online Labs ARM-based cloud platform, who have also offered help to io.js). ARMv8 is the logical extension of this, but also has exciting potential for server-side applications, particularly given the new 64-bit support.
+ -->
+
 io.jsの開始当初から、Rodは IoT, ホビー用途, またサーバーとしてのARMの役割について大きな期待と支持をしてきました。すでに各リリースにおいてARMv6ビルド（Raspberry Piなど）とARMv7ビルド（多くの人気デバイス、例えばio.jsのサポートを表明しているOnline Labsのクラウドプラットフォームなど）を用意しています。ARMv8の追加は自然な流れですが、特に64-bitのサポートはサーバーサイドアプリケーションの可能性が広がります。
 
-<!-- The build team is in the process of being given access to the Linaro ARMv8 Server Cluster for integration with the io.js CI platform, which should eventually lead to regular ARMv8 binary releases. -->
+<!--
+The build team is in the process of being given access to the Linaro ARMv8 Server Cluster for integration with the io.js CI platform, which should eventually lead to regular ARMv8 binary releases.
+-->
+
 Buildチームでは、io.jsのCIプラットフォームとの連携用にLinaro ARMv8 Server Clusterへのアクセスを得る予定で、これにより毎リリースでARMv8のバイナリ配布が可能になります。
 
-<!-- ## Community Updates -->
+<!--
+## Community Updates
+-->
+
 ## コミュニティの動き
 
-<!-- * [**Reconciliation Proposal**](https://github.com/iojs/io.js/issues/978): The io.js project is preparing a plan for reconciliation that can be brought to The Node.js Foundation. Input from the community is very important at this early stage so please leave a comment. 
-* **New internal C++ Streams API**: A [fresh C++ Streams API](https://github.com/iojs/io.js/commit/b9686233fc0be679d7ba1262b611711629ee334e) landed in io.js this week, allowing you to wrap a TLS stream into another TLS stream. 
+<!--
+* [**Reconciliation Proposal**](https://github.com/iojs/io.js/issues/978): The io.js project is preparing a plan for reconciliation that can be brought to The Node.js Foundation. Input from the community is very important at this early stage so please leave a comment.
+* **New internal C++ Streams API**: A [fresh C++ Streams API](https://github.com/iojs/io.js/commit/b9686233fc0be679d7ba1262b611711629ee334e) landed in io.js this week, allowing you to wrap a TLS stream into another TLS stream.
 * **io.js Roadmap**: [The Roadmap](https://github.com/iojs/io.js/blob/v1.x/ROADMAP.md) is the plan for the future of io.js. It presents the plans for the stability policy, and lists what the immediate priorities for io.js as a whole are.
-* **Roadmap Slides Finished and Ready for Translation**: The set of introductory slides for the Roadmap of io.js [have been finished, and are ready for translation](https://github.com/iojs/roadmap/issues/18). Do you think you could present them to a group near you? Comment and we'll work with you to prepare you to present! 
+* **Roadmap Slides Finished and Ready for Translation**: The set of introductory slides for the Roadmap of io.js [have been finished, and are ready for translation](https://github.com/iojs/roadmap/issues/18). Do you think you could present them to a group near you? Comment and we'll work with you to prepare you to present!
 * **Microsoft io.js How-To for Azure Websites**: Microsoft [published a how-to](http://azure.microsoft.com/en-us/documentation/articles/web-sites-nodejs-iojs/) tutorial for their Azure platform that describes how to use io.js with Azure Websites.
 * **Floobits moves to io.js**: The code pairing software Floobits [converted their platform to io.js](https://news.floobits.com/2015/02/23/on-moving-to-io.js/), in part because of frustration with Node's slower release cycle, because the inclusion of more ES6 features without the need for the `--harmony` flag, and because they felt changes from 0.10.0 to 0.12.0 weren't very big.
 * **Anand Mani Sankar's _Node.js vs io.js: Why the fork?!?_**: Anand wrote a good, for the most part objective, [post about the recent history of io.js](http://anandmanisankar.com/posts/nodejs-iojs-why-the-fork/#.VO82hE60PVw.twitter), and what we hope to achieve with it. A good read for people who aren't engaged in the community to catch up with.
 * **iojs-jp - New io.js Japanese Blog**: The iojs-jp community has created a [localized io.js related blog](http://blog.iojs.jp/) to disseminate content in their language. If you're interested, take a look!
 * **iojs-cn - New io.js Chinese Blog**: Similarly to the iojs-jp community, the iojs-cn community created a [localized blog](http://cn.iojs.org/) to publish posts about io.js to in their language. Make sure to visit if you're curious about iojs-cn or Chinese news about io.js!
-* **[Roadmap Slides Review](https://www.youtube.com/watch?v=etI_UD4wXlo)** - A review of the roadmap slides before they were released to ensure they met with the message the project upholds. -->
+* **[Roadmap Slides Review](https://www.youtube.com/watch?v=etI_UD4wXlo)** - A review of the roadmap slides before they were released to ensure they met with the message the project upholds.
+-->
+
 * [**和解プロポーザル**](https://github.com/iojs/io.js/issues/978): io.js プロジェクトではNode.js Foundationとの話し合いに向けて和解プランを立て始めました。初期段階でのコミュニティ意見参加はとても重要です、ぜひコメントを。
-* **新 C++ Streams 内部API**: 全く新しい [C++ Streams API](https://github.com/iojs/io.js/commit/b9686233fc0be679d7ba1262b611711629ee334e)が今週io.jsに追加され、TLS streamを他のTLS streamで包むことができるようになりました。 
+* **新 C++ Streams 内部API**: 全く新しい [C++ Streams API](https://github.com/iojs/io.js/commit/b9686233fc0be679d7ba1262b611711629ee334e)が今週io.jsに追加され、TLS streamを他のTLS streamで包むことができるようになりました。
 * **io.js ロードマップ**: 主に安定性ポリシーと直近の優先項目についての[将来プラン](https://github.com/iojs/io.js/blob/v1.x/ROADMAP.md)
 * **ロードマップのスライド完成 (翻訳用に準備完了）**: io.jsのロードマップについての紹介スライドが[完成し翻訳用に準備完了](https://github.com/iojs/roadmap/issues/18)しました。ぜひローカルイベントで発表しませんか？ コメントしてくれたらプレゼン準備をお手伝いします!
 * **MicrosoftによるAzure Websitesでのio.js解説**: Azure Websites上でのio.jsの[使い方ハウツー記事](http://azure.microsoft.com/en-us/documentation/articles/web-sites-nodejs-iojs/).
@@ -63,13 +95,20 @@ Buildチームでは、io.jsのCIプラットフォームとの連携用にLinar
 * **iojs-cn - io.js中国語ブログ**: 日本語コミュニティと同じく、中国語コミュニティも[現地ブログ](http://cn.iojs.org/)でio.jsの情報発信を開始。中国語でのio.jsニュースに興味がある場合はぜひチェックを!
 * **[ロードマップスライドのレビュー](https://www.youtube.com/watch?v=etI_UD4wXlo)** - スライドリリース前に行われたプロジェクトに沿ったメッセージになっているかの確認ミーティング
 
-<!-- # io.js Support Added -->
+<!--
+# io.js Support Added
+-->
+
 ## io.jsサポートの追加
-<!-- * **[Wallby.js](http://wallabyjs.com/)**, a while-you-write testing library for JavaScript, hit version 1.0 and [added support for io.js](http://dm.gl/2015/02/23/wallaby-version-one/)!
+
+<!--
+* **[Wallby.js](http://wallabyjs.com/)**, a while-you-write testing library for JavaScript, hit version 1.0 and [added support for io.js](http://dm.gl/2015/02/23/wallaby-version-one/)!
 * **[jsdom](https://github.com/tmpvar/jsdom)**, an implementation of the WHATWG DOM and HTML standards, just hit [version 4.0.0](https://github.com/tmpvar/jsdom/blob/master/Changelog.md#400), which added a _requirement_ of io.js.
 * **[give](https://github.com/mmalecki/give)**'s creator [tweeted](https://twitter.com/maciejmalecki/status/569629100215816192) that newer versions of give support io.js. Give is a git-based node.js/io.js version manager.
 * The **Firebase Realtime Client**, the official web/node.js JavaScript client for Firebase, [tweeted](https://twitter.com/FirebaseRelease/status/570000737343647744) that they added support for io.js in [version 2.2.1](https://www.firebase.com/docs/web/changelog.html#section-realtime-client)
-* **Semaphore**, a hosted continuous integrations service, [tweeted](https://twitter.com/semaphoreapp/status/570987355005431809) about added io.js support in their [Platform update on February 24th, 2015](https://semaphoreapp.com/blog/2015/02/17/platform-update-on-february-24th.html?utm_source=twitter&utm_medium=social&utm_content=platform_update_launch&utm_campaign=platformupdate).  -->
+* **Semaphore**, a hosted continuous integrations service, [tweeted](https://twitter.com/semaphoreapp/status/570987355005431809) about added io.js support in their [Platform update on February 24th, 2015](https://semaphoreapp.com/blog/2015/02/17/platform-update-on-february-24th.html?utm_source=twitter&utm_medium=social&utm_content=platform_update_launch&utm_campaign=platformupdate).
+-->
+
 * **[Wallby.js](http://wallabyjs.com/)**　(javascrip用テストライブラリ)が バージョン1.0 で[io.jsをサポート](http://dm.gl/2015/02/23/wallaby-version-one/)!
 * **[jsdom](https://github.com/tmpvar/jsdom)**　(DOMシュミレーションパッケージ) が[新バージョン 4.0.0](https://github.com/tmpvar/jsdom/blob/master/Changelog.md#400)でio.js_のみ_をサポート。
 * **[give](https://github.com/mmalecki/give)**の作者が新バージョンのgiveではio.jsをサポートと[ツイート](https://twitter.com/maciejmalecki/status/569629100215816192) (giveはgitベースの node.js/io.js バージョンマネージャー)

--- a/weekly/2015-04-03.md
+++ b/weekly/2015-04-03.md
@@ -34,6 +34,7 @@ This week we had one io.js release [v1.6.3](https://iojs.org/dist/v1.6.3/), comp
 * **V8**: minor bug-fix upgrade for V8 to 4.1.0.27.
 * **npm**: upgrade npm to 2.7.4. See [npm CHANGELOG.md](https://github.com/npm/npm/blob/master/CHANGELOG.md#v274-2015-03-20) for details.
 -->
+
 * **fs**: 一定の環境において`fs.writeFileSync()`、 append-modeの`fs.writeFile()`、`fs.writeFileSync()` によるファイル破損バグ報告が[#1058](https://github.com/iojs/io.js/issues/1058)であり、[#1063](https://github.com/iojs/io.js/pull/1063) (Olov Lassus)にて修正されました。
 * **iojs**: JavaScriptモジュールをパブリックAPIにさらすことなくコア内部でシェアできるように "internal modules" API が追加されました。この機能はコアのみで利用できます。[#848](https://github.com/iojs/io.js/pull/848) (Vladimir Kurchatkin)
 * **timers**: タイマーにおけるマイナーバグが2つ修正されました。


### PR DESCRIPTION
Because http://blog.iojs.jp/ ’s style has broken because of lack of new
line between comment and text
